### PR TITLE
add Page Views

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[java-ee-kickoff-app](http://javaeekickoff.omnifaces.org/) [![Build Status](https://travis-ci.org/javaeekickoff/java-ee-kickoff-app.svg?branch=master)](https://travis-ci.org/javaeekickoff/java-ee-kickoff-app)
+[java-ee-kickoff-app](http://javaeekickoff.omnifaces.org/) [![Build Status](https://travis-ci.org/javaeekickoff/java-ee-kickoff-app.svg?branch=master)](https://travis-ci.org/javaeekickoff/java-ee-kickoff-app) [![Hits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2Fjavaeekickoff%2Fjava-ee-kickoff-app&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=PAGE+VIEWS&edge_flat=false)](https://hits.seeyoufarm.com)
 ===================
 
 Basic project template to kickoff a new Java EE web application.


### PR DESCRIPTION
When we add this service, it will count every hit of this repo. And this will guide us more about the visitors each day and will indicate the total views. For me, this is very helpful both for us and for those will view this repo seeing this page views. If there is the website built from this repo, it can be simply added there too.

![image](https://user-images.githubusercontent.com/47092464/98457341-159dcd00-21c1-11eb-8b25-5824bb11e910.png)
