### PR TITLE
Store Instant as Long. Fixes javaeekickoff/java-ee-kickoff-app#46

### DIFF
--- a/src/main/java/org/example/kickoff/business/service/LoginTokenService.java
+++ b/src/main/java/org/example/kickoff/business/service/LoginTokenService.java
@@ -52,6 +52,7 @@ public class LoginTokenService extends BaseEntityService<Long, LoginToken> {
 
 	public void removeExpired() {
 		createNamedQuery("LoginToken.removeExpired")
+			.setParameter("expiration", Instant.now())
 			.executeUpdate();
 	}
 

--- a/src/main/java/org/example/kickoff/business/service/PersonService.java
+++ b/src/main/java/org/example/kickoff/business/service/PersonService.java
@@ -5,6 +5,7 @@ import static org.example.kickoff.model.Group.USER;
 import static org.omnifaces.persistence.JPA.getOptionalSingleResult;
 import static org.omnifaces.utils.security.MessageDigests.digest;
 
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.Map;
@@ -118,6 +119,7 @@ public class PersonService extends BaseEntityService<Long, Person> {
 	public Optional<Person> findByLoginToken(String loginToken, TokenType type) {
 		return getOptionalSingleResult(createNamedTypedQuery("Person.getByLoginToken")
 			.setParameter("tokenHash", digest(loginToken, "SHA-256"))
+			.setParameter("expiration", Instant.now())
 			.setParameter("tokenType", type));
 	}
 

--- a/src/main/java/org/example/kickoff/config/InstantConverter.java
+++ b/src/main/java/org/example/kickoff/config/InstantConverter.java
@@ -1,12 +1,11 @@
 package org.example.kickoff.config;
  import java.time.Instant;
-import java.util.Date;
 
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 
  /**
-  * Converts the JDK 8 / JSR 310 <code>Instant</code> type to <code>Date</code> for
+  * Converts the JDK 8 / JSR 310 <code>Instant</code> type to <code>Long</code> for
   * usage with JPA.
   *
   * <p>
@@ -18,23 +17,23 @@ import jakarta.persistence.Converter;
   * @author Arjan Tijms
   */
  @Converter(autoApply = true)
- public class InstantConverter implements AttributeConverter<Instant, Date> {
+ public class InstantConverter implements AttributeConverter<Instant, Long> {
 
  	@Override
- 	public Date convertToDatabaseColumn(Instant instant) {
+	public Long convertToDatabaseColumn(Instant instant) {
  		if (instant == null) {
  			return null;
  		}
 
- 		return Date.from(instant);
+		return instant.toEpochMilli();
  	}
 
  	@Override
- 	public Instant convertToEntityAttribute(Date date) {
+	public Instant convertToEntityAttribute(Long date) {
  		if (date == null) {
  			return null;
  		}
 
- 		return date.toInstant();
+		return Instant.ofEpochMilli(date);
  	}
  }

--- a/src/main/resources/META-INF/LoginToken.xml
+++ b/src/main/resources/META-INF/LoginToken.xml
@@ -21,7 +21,7 @@
 			FROM
 				LoginToken _loginToken
 			WHERE
-				_loginToken.expiration &lt; CURRENT_TIMESTAMP
+				_loginToken.expiration &lt; :expiration
 		</query>
 	</named-query>
 </entity-mappings>

--- a/src/main/resources/META-INF/Person.xml
+++ b/src/main/resources/META-INF/Person.xml
@@ -29,7 +29,7 @@
 			WHERE
 				_loginToken.tokenHash = :tokenHash AND
 				_loginToken.type = :tokenType AND
-				_loginToken.expiration &gt; CURRENT_TIMESTAMP
+				_loginToken.expiration &gt; :expiration
 		</query>
 	</named-query>
 </entity-mappings>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -21,9 +21,8 @@
             <!-- 
                 Needed because org.example.kickoff.config.InstantConverter is used, and Hibernate does not seem to fully apply it.
                 Without this it will still think the SQL type is 3003 (org.hibernate.types.SqlTypes.TIMESTAMP_UTC) and therefor complain
-                when it's actually 93 (java.sql.Types.TIMESTAMP).
             -->
-            <property name="hibernate.type.preferred_instant_jdbc_type" value="TIMESTAMP"/>
+            <property name="hibernate.type.preferred_instant_jdbc_type" value="BIGINT"/>
             
 			<property name="wildfly.jpa.twophasebootstrap" value="false" /> <!-- https://issues.jboss.org/browse/WFLY-2727 -->
             

--- a/src/test/resources/dbunit/UserServiceTest.xml
+++ b/src/test/resources/dbunit/UserServiceTest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dataset>
-	<person id="1001" email="test@test.test" firstName="test" lastName="test" emailVerified="1" created="2018-03-10 11:11:11" lastModified="2018-03-10 11:11:11" />
+	<person id="1001" email="test@test.test" firstName="test" lastName="test" emailVerified="1" created="1520680271000" lastModified="1520680271000" />
 	<credentials person_id="1001" passwordHash="E0K/IHFmCEwlgr4R5gaBOQy2Kwh+IwkMeWWBDer6x2k=" salt="fVJkXbtOO1HAs3GOPtwB9WGCsOSvdBITJsBAMzvN1Y5rWLbdEZFu6A==" />
 	<person_groups person_id="1001" groups="USER" />
 </dataset>

--- a/src/test/resources/test-persistence.xml
+++ b/src/test/resources/test-persistence.xml
@@ -25,9 +25,8 @@
             <!-- 
                 Needed because org.example.kickoff.config.InstantConverter is used, and Hibernate does not seem to fully apply it.
                 Without this it will still think the SQL type is 3003 (org.hibernate.types.SqlTypes.TIMESTAMP_UTC) and therefor complain
-                when it's actually 93 (java.sql.Types.TIMESTAMP).
              -->
-            <property name="hibernate.type.preferred_instant_jdbc_type" value="TIMESTAMP"/>
+            <property name="hibernate.type.preferred_instant_jdbc_type" value="BIGINT"/>
             
 			<property name="wildfly.jpa.twophasebootstrap" value="false" /> <!-- https://issues.jboss.org/browse/WFLY-2727 -->
 			


### PR DESCRIPTION
Store Instant as Long. Fixes javaeekickoff/java-ee-kickoff-app#46

Upgrading to wildfly 29 and you can remove hibernate.type.preferred_instant_jdbc_type